### PR TITLE
Fix/28 walk detail - cctv 위, 경도 리스트 받아오도록 수정

### DIFF
--- a/src/main/java/growthook/org/bamgang/trail/domain/Trail.java
+++ b/src/main/java/growthook/org/bamgang/trail/domain/Trail.java
@@ -25,9 +25,6 @@ public class Trail {
     @Column(name = "trail_distance")
     private Double distance;
 
-    @Column(name = "trail_cctv_arr")
-    private Integer[] cctvArr;
-
     @Column(name = "trail_rating")
     private Double rating;
 
@@ -39,4 +36,10 @@ public class Trail {
 
     @Column(name = "trail_region")
     private String region;
+
+    @Column(name = "latitude_list")
+    private Double[] latitudeList;
+
+    @Column(name = "longitude_list")
+    private Double[] longitudeList;
 }

--- a/src/main/java/growthook/org/bamgang/trail/dto/response/GetTrailResponseDto.java
+++ b/src/main/java/growthook/org/bamgang/trail/dto/response/GetTrailResponseDto.java
@@ -13,11 +13,11 @@ public class GetTrailResponseDto {
     private String detail;
     private String image;
     private Double distance;
-    private Integer[] cctvArr;
     private Double rating;
     private Double time;
     private String level;
     private String region;
-
+    private Double[] latitudeList;
+    private Double[] longitudeList;
 
 }

--- a/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
@@ -25,11 +25,12 @@ public class TrailServiceImpl implements TrailService{
                 .detail(trail.getDetail())
                 .image(trail.getImage())
                 .distance(trail.getDistance())
-                .cctvArr(trail.getCctvArr())
                 .rating(trail.getRating())
                 .time(trail.getTime())
                 .level(trail.getLevel())
                 .region(trail.getRegion())
+                .latitudeList(trail.getLatitudeList())
+                .longitudeList(trail.getLongitudeList())
                 .build();
     }
 }


### PR DESCRIPTION
- close #28  

- 산책로 detail 확인 시 기존에 cctv id 리스트를 받아왔던 것 에서, cctv의 위,경도 리스트를 받아오는 것으로 수정했습니다.
![image](https://github.com/seoul-night/ddubam-server/assets/83462874/c6be6353-d2a1-418d-95af-1ad2de979f2a)
