### PR TITLE
Feature/6 walk around - 사용자의 위치(위도, 경도)를 기반으로 주변 산책로 반환하는 API

### DIFF
--- a/src/main/java/growthook/org/bamgang/trail/controller/TrailController.java
+++ b/src/main/java/growthook/org/bamgang/trail/controller/TrailController.java
@@ -5,6 +5,8 @@ import growthook.org.bamgang.trail.dto.response.GetTrailResponseDto;
 import growthook.org.bamgang.trail.service.TrailService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/walks")
 public class TrailController {
@@ -12,9 +14,16 @@ public class TrailController {
     public TrailController(TrailService trailService) {
         this.trailService = trailService;
     }
+
+    // 산책로 상세정보 조회
     @GetMapping("/{trailId}")
     public GetTrailResponseDto getTrailById(@PathVariable("trailId") Integer trailId){
         return trailService.getTrailById(trailId);
+    }
+
+    @GetMapping("/near/{latitude}/{longitude}")
+    public List<GetTrailResponseDto> getNearTrail(@PathVariable("latitude") Double latitude, @PathVariable("longitude") Double longitude){
+        return trailService.getNearTrail(latitude, longitude);
     }
 
 }

--- a/src/main/java/growthook/org/bamgang/trail/domain/TrailStart.java
+++ b/src/main/java/growthook/org/bamgang/trail/domain/TrailStart.java
@@ -1,0 +1,33 @@
+package growthook.org.bamgang.trail.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "trailstart")
+@Getter
+public class TrailStart {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trail_id")
+    private Integer trailId;
+
+    @Column(name = "start_latitude1")
+    private Double startLatitude1;
+
+    @Column(name = "start_longitude1")
+    private Double startLongitude1;
+
+    @Column(name = "start_latitude2")
+    private Double startLatitude2;
+
+    @Column(name = "start_longitude2")
+    private Double startLongitude2;
+
+    @Column(name = "start_latitude3")
+    private Double startLatitude3;
+
+    @Column(name = "start_longitude3")
+    private Double startLongitude3;
+}

--- a/src/main/java/growthook/org/bamgang/trail/dto/request/GetTrailRequestDto.java
+++ b/src/main/java/growthook/org/bamgang/trail/dto/request/GetTrailRequestDto.java
@@ -1,5 +1,5 @@
 package growthook.org.bamgang.trail.dto.request;
 
 public class GetTrailRequestDto {
-    private int trailId;
+    // empty class...
 }

--- a/src/main/java/growthook/org/bamgang/trail/repository/TrailRepository.java
+++ b/src/main/java/growthook/org/bamgang/trail/repository/TrailRepository.java
@@ -4,7 +4,8 @@ import growthook.org.bamgang.trail.domain.Trail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TrailRepository extends JpaRepository<Trail, Integer> {
-
 }

--- a/src/main/java/growthook/org/bamgang/trail/repository/TrailStartRepository.java
+++ b/src/main/java/growthook/org/bamgang/trail/repository/TrailStartRepository.java
@@ -1,0 +1,19 @@
+package growthook.org.bamgang.trail.repository;
+
+import growthook.org.bamgang.trail.domain.TrailStart;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TrailStartRepository extends JpaRepository<TrailStart, Integer> {
+    List<TrailStart> findTrailIdsByStartLatitude1BetweenAndStartLongitude1BetweenAndStartLatitude2BetweenAndStartLongitude2BetweenAndStartLatitude3BetweenAndStartLongitude3Between(
+            Double minLatitude, Double maxLatitude,
+            Double minLongitude, Double maxLongitude,
+            Double minLatitude1, Double maxLatitude1,
+            Double minLongitude1, Double maxLongitude1,
+            Double minLatitude2, Double maxLatitude2,
+            Double minLongitude2, Double maxLongitude2
+    );
+}

--- a/src/main/java/growthook/org/bamgang/trail/service/TrailService.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailService.java
@@ -1,8 +1,17 @@
 package growthook.org.bamgang.trail.service;
 
+import growthook.org.bamgang.trail.domain.Trail;
 import growthook.org.bamgang.trail.dto.response.GetTrailResponseDto;
+
+import java.util.List;
 
 public interface TrailService {
 
+    // 산책로 상세정보 조회
     public GetTrailResponseDto getTrailById(Integer trailId);
+
+    // 주변 산책로 조회
+    List<GetTrailResponseDto> getNearTrail(Double latitude, Double longitude);
+
+    GetTrailResponseDto convertToResponseDto(Trail trail);
 }

--- a/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
@@ -1,24 +1,87 @@
 package growthook.org.bamgang.trail.service;
 
 import growthook.org.bamgang.trail.domain.Trail;
+import growthook.org.bamgang.trail.domain.TrailStart;
 import growthook.org.bamgang.trail.dto.response.GetTrailResponseDto;
 import growthook.org.bamgang.trail.repository.TrailRepository;
+import growthook.org.bamgang.trail.repository.TrailStartRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class TrailServiceImpl implements TrailService{
 
     public final TrailRepository trailRepository;
+    public final TrailStartRepository trailStartRepository;
 
+    // 산책로 상세정보 조회
     @Autowired
-    public TrailServiceImpl(TrailRepository trailRepository) {
+    public TrailServiceImpl(TrailRepository trailRepository, TrailStartRepository trailStartRepository) {
         this.trailRepository = trailRepository;
+        this.trailStartRepository = trailStartRepository;
     }
     public GetTrailResponseDto getTrailById(Integer trailId) {
         Trail trail = trailRepository.findById(trailId)
                 .orElseThrow(() -> new RuntimeException("Trail not found with id: " + trailId));
         // Domain 객체를 Response DTO로 변환
+        return GetTrailResponseDto.builder()
+                .id(trail.getId())
+                .title(trail.getTitle())
+                .detail(trail.getDetail())
+                .image(trail.getImage())
+                .distance(trail.getDistance())
+                .rating(trail.getRating())
+                .time(trail.getTime())
+                .level(trail.getLevel())
+                .region(trail.getRegion())
+                .latitudeList(trail.getLatitudeList())
+                .longitudeList(trail.getLongitudeList())
+                .build();
+    }
+
+    // 주변 산책로 조회
+    @Override
+    public List<GetTrailResponseDto> getNearTrail(Double latitude, Double longitude) {
+        // 조회할 범위 설정
+        Double minLatitude = latitude - 0.01;
+        Double maxLatitude = latitude + 0.01;
+        Double minLongitude = longitude - 0.01;
+        Double maxLongitude = longitude + 0.01;
+
+        // 해당 범위 내에 있는 주변 산책로들을 조회한다.
+        List<TrailStart> nearTrailStarts = trailStartRepository.findTrailIdsByStartLatitude1BetweenAndStartLongitude1BetweenAndStartLatitude2BetweenAndStartLongitude2BetweenAndStartLatitude3BetweenAndStartLongitude3Between(
+                // 3개의 출발점을 모두 조회해야 하므로, 같은 파라미터를 3개씩 보내야 한다.
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude,
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude,
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude
+        );
+
+        // 조회된 TrailStart들의 trailId를 사용해여 해당하는 Trail 정보 조회
+        List<Trail> nearByTrails = nearTrailStarts.stream()
+                .map(TrailStart::getTrailId)
+                .map(trailRepository::findById)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        // 가져온 리스트에서 산책로들을 GetTrailRepsponseDto로 변환하려 리스트로 반환함.
+        return nearByTrails.stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    // trail객체를 GeteTrailResponseDto 객체로 바꿔주는 함수.
+    @Override
+    public GetTrailResponseDto convertToResponseDto(Trail trail) {
+
+        // trail 정보를 GetTrailResponseDto로 변환
         return GetTrailResponseDto.builder()
                 .id(trail.getId())
                 .title(trail.getTitle())


### PR DESCRIPTION
- close #6 
- 사용자의 위도, 경도를 받아오면 해당 위도, 경도를 기준으로 일정 범위를 정하고
- db의 trailStart table에서 각각의 산책로마다 주어진 3개의 위도, 경도를 비교해보며 해당 범위 안에 위도, 경도가 포함된다면 해당  행 반환.
- 반환받은 trailstart 객체에서 id를 뽑아내서 trail 찾기
- trail 리스트 반환.
![image](https://github.com/seoul-night/ddubam-server/assets/83462874/4f1850dc-6c66-4753-8c15-7c3e6c457eb2)
