### PR TITLE
fix: #44- 관광지 주변 산책로 조회 기능 수정

### DIFF
--- a/src/main/java/growthook/org/bamgang/attractions/controller/AttractionController.java
+++ b/src/main/java/growthook/org/bamgang/attractions/controller/AttractionController.java
@@ -28,8 +28,8 @@ public class AttractionController {
         return attractionService.selectAll();
     }
 
-    @GetMapping("/{latitude}/{longitiude}")
-    public GetAttractionPointDto getAttractionPointDto(@PathVariable Double latitude, @PathVariable Double longitiude) {
-        return attractionService.getAttractionPointDto(latitude,longitiude);
+    @GetMapping("/{latitude}/{longitude}")
+    public GetAttractionPointDto getAttractionPointDto(@PathVariable("latitude") Double latitude, @PathVariable("longitude") Double longitude) {
+        return attractionService.getAttractionPointDto(latitude,longitude);
     }
 }

--- a/src/main/java/growthook/org/bamgang/attractions/service/AttractionService.java
+++ b/src/main/java/growthook/org/bamgang/attractions/service/AttractionService.java
@@ -48,9 +48,60 @@ public class AttractionService {
         return list;
     }
 
-    public GetAttractionPointDto getAttractionPointDto(double latitude, double longitude) {
-        List<GetTrailResponseDto> trailList = trailService.getNearTrail(latitude,longitude);
-        Integer trailId = trailList.get(0).getId();
+    public GetAttractionPointDto getAttractionPointDto(Double latitude, Double longitude) {
+        List<GetTrailResponseDto> trailList = trailService.getNearAttractionTrail(latitude, longitude);
+
+        if(trailList.isEmpty()){
+            return null;
+        }
+
+        double minDistance = Double.MAX_VALUE;
+        int minDistanceIndex = -1;
+
+        // 주변 관광지 탐색
+        for (int i = 0; i < trailList.size(); i++) {
+            GetTrailResponseDto nearTrail = trailList.get(i);
+
+            Double[] latitudeArray = nearTrail.getLatitudeList();
+            Double[] longitudeArray = nearTrail.getLongitudeList();
+
+            // 현재 관광지와의 최소 거리 초기화
+            double curMinDistance = Double.MAX_VALUE;
+
+            // 주변 관광지의 각 좌표에 대한 탐색
+            for (int j = 0; j < latitudeArray.length; j++) {
+                double nearLatitude = latitudeArray[j];
+                double nearLongitude = longitudeArray[j];
+
+                // 위도와 경도의 차이를 라디안으로 변환
+                double latDiff = Math.toRadians(nearLatitude - latitude);
+                double lonDiff = Math.toRadians(nearLongitude - longitude);
+
+                // 하버사인 공식을 사용하여 거리 계산
+                double a = Math.sin(latDiff / 2) * Math.sin(latDiff / 2) +
+                        Math.cos(Math.toRadians(latitude)) * Math.cos(Math.toRadians(nearLatitude)) *
+                                Math.sin(lonDiff / 2) * Math.sin(lonDiff / 2);
+
+                double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+                // 거리 계산 (지구 반지름 6371 km)
+                double distance = 6371 * c;
+
+                // 최소 거리 갱신
+                curMinDistance = Math.min(curMinDistance, distance);
+            }
+
+            // 현재 관광지의 최소 거리가 전체 최소 거리보다 작으면 갱신
+            if (curMinDistance < minDistance) {
+                minDistance = curMinDistance;
+                minDistanceIndex = i;
+            }
+        }
+
+        if (minDistanceIndex == -1) {
+            return null; // 또는 예외 처리
+        }
+        Integer trailId = trailList.get(minDistanceIndex).getId();
         return GetAttractionPointDto.builder().trailId(trailId).build();
     }
 

--- a/src/main/java/growthook/org/bamgang/trail/service/TrailService.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailService.java
@@ -15,5 +15,8 @@ public interface TrailService {
 
     GetTrailResponseDto convertToResponseDto(Trail trail);
 
+    // 주변 산책로 조회
+    List<GetTrailResponseDto> getNearAttractionTrail(Double latitude, Double longitude);
+
     List<GetTrailResponseDto> getPopularTrail();
 }

--- a/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
@@ -88,6 +88,41 @@ public class TrailServiceImpl implements TrailService{
     }
 
 
+    // 주변 산책로 조회
+    @Override
+    public List<GetTrailResponseDto> getNearAttractionTrail(Double latitude, Double longitude) {
+        // 조회할 범위 설정
+        Double minLatitude = latitude - 0.2;
+        Double maxLatitude = latitude + 0.2;
+        Double minLongitude = longitude - 0.3;
+        Double maxLongitude = longitude + 0.3;
+
+        // 해당 범위 내에 있는 주변 산책로들을 조회한다.
+        List<TrailStart> nearTrailStarts = trailStartRepository.findTrailIdsByStartLatitude1BetweenAndStartLongitude1BetweenAndStartLatitude2BetweenAndStartLongitude2BetweenAndStartLatitude3BetweenAndStartLongitude3Between(
+                // 3개의 출발점을 모두 조회해야 하므로, 같은 파라미터를 3개씩 보내야 한다.
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude,
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude,
+                minLatitude, maxLatitude,
+                minLongitude, maxLongitude
+        );
+
+        // 조회된 TrailStart들의 trailId를 사용해여 해당하는 Trail 정보 조회
+        List<Trail> nearByTrails = nearTrailStarts.stream()
+                .map(TrailStart::getTrailId)
+                .map(trailRepository::findById)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        // 가져온 리스트에서 산책로들을 GetTrailRepsponseDto로 변환하려 리스트로 반환함.
+        return nearByTrails.stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+
     // 인기있는 산책로 리스트 가져오기.
     @Override
     public List<GetTrailResponseDto> getPopularTrail() {


### PR DESCRIPTION
- resolve #44  
- 내 위치 주변 산책로 탐색할 때와 별개로 관광지 주변 산책로를 검색하는 메소드 생성
    - 내 위치와 검색 범위를 다르게 설정함
- 표시할 때는 범위 내의 산책로와 관광지 사이의 거리를 계산하여 가장 가까운 산책로 하나만 반환하도록 메소드 수정
![image](https://github.com/seoul-night/ddubam-server/assets/83462874/a10e76f6-a063-4dd5-9c2f-f7bc5f6f2a51)
