### PR TITLE
fix: #54-근처 산책로를 찾을 때, 찾는 범위를 위,경도 0.01에서 0.05로 변경

### DIFF
--- a/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
+++ b/src/main/java/growthook/org/bamgang/trail/service/TrailServiceImpl.java
@@ -57,10 +57,10 @@ public class TrailServiceImpl implements TrailService{
     @Override
     public List<GetTrailResponseDto> getNearTrail(Double latitude, Double longitude) {
         // 조회할 범위 설정
-        Double minLatitude = latitude - 0.01;
-        Double maxLatitude = latitude + 0.01;
-        Double minLongitude = longitude - 0.01;
-        Double maxLongitude = longitude + 0.01;
+        Double minLatitude = latitude - 0.05;
+        Double maxLatitude = latitude + 0.05;
+        Double minLongitude = longitude - 0.05;
+        Double maxLongitude = longitude + 0.05;
 
         // 해당 범위 내에 있는 주변 산책로들을 조회한다.
         List<Integer> nearTrailStarts = trailStartRepository.findTrailIdsByCoordinates(


### PR DESCRIPTION
- resolve #54 

![image](https://github.com/seoul-night/ddubam-server/assets/83462874/7e47fff6-743a-4f8d-9537-767f1183fd2a)

강남역 주변에서 찾을 때, 강남구 주변에서 6개를 찾음.